### PR TITLE
Add Documentation Site

### DIFF
--- a/docs/Available-Tools.md
+++ b/docs/Available-Tools.md
@@ -1,0 +1,241 @@
+# Available Tools
+
+GitHub CLI MCP provides access to various GitHub CLI tools through the Model Context Protocol. Here's a comprehensive list of the available tools organized by category.
+
+## Pull Request Tools
+
+### gh_pr_list
+
+Lists pull requests in a repository.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `state` (optional): State of PRs to list (open, closed, merged, all)
+- `assignee` (optional): Filter by assignee
+- `author` (optional): Filter by author
+- `label` (optional): Filter by label(s)
+- `limit` (optional): Maximum number of items to fetch
+- `search` (optional): Search query
+
+### gh_pr_view
+
+View a specific pull request.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `number` (required): Pull request number
+- `web` (optional): Open in the browser
+- `comments` (optional): Show PR comments
+
+### gh_pr_create
+
+Create a new pull request.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `title` (optional): Title for the PR
+- `body` (optional): Body content for the PR
+- `body_file` (optional): Path to a file containing the body content
+- `base` (optional): Base branch name
+- `head` (optional): Head branch name
+- `draft` (optional): Create as a draft PR
+- `reviewer` (optional): Reviewer(s) to request
+
+### gh_pr_close
+
+Close a pull request.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `number` (required): Pull request number
+- `comment` (optional): Add a closing comment
+- `delete_branch` (optional): Delete the local and remote branch after close
+
+## Issue Tools
+
+### gh_issue_list
+
+List issues in a repository.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `state` (optional): State of issues to list (open, closed, all)
+- `assignee` (optional): Filter by assignee
+- `author` (optional): Filter by author
+- `label` (optional): Filter by label(s)
+- `limit` (optional): Maximum number of items to fetch
+- `search` (optional): Search query
+- `milestone` (optional): Filter by milestone
+- `project` (optional): Filter by project
+
+### gh_issue_view
+
+View a specific issue.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `number` (required): Issue number
+- `web` (optional): Open in the browser
+- `comments` (optional): Show issue comments
+
+### gh_issue_create
+
+Create a new issue.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `title` (optional): Title for the issue
+- `body` (optional): Body content for the issue
+- `body_file` (optional): Path to a file containing the body content
+
+### gh_issue_close
+
+Close an issue.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `number` (required): Issue number
+- `comment` (optional): Add a closing comment
+
+## Repository Tools
+
+### gh_repo_view
+
+View a repository.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `web` (optional): Open in the browser
+
+### gh_repo_list
+
+List repositories.
+
+**Parameters:**
+- `limit` (optional): Maximum number of repositories to list
+- `owner` (optional): Filter by owner
+- `language` (optional): Filter by language
+- `visibility` (optional): Filter by visibility (public, private)
+
+## Project Tools
+
+### gh_project_view
+
+View a project.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `number` (required): Project number
+- `web` (optional): Open in the browser
+
+### gh_project_list
+
+List projects.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `limit` (optional): Maximum number of projects to list
+- `format` (optional): Format output with a Go template
+
+### gh_project_create
+
+Create a new project.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `title` (required): Title for the project
+- `body` (optional): Description for the project
+
+### gh_project_edit
+
+Edit a project.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `number` (required): Project number
+- `title` (optional): New title for the project
+- `body` (optional): New description for the project
+
+## Workflow Tools
+
+### gh_workflow_list
+
+List workflows in a repository.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `all` (optional): Show all workflows, including disabled ones
+
+### gh_workflow_view
+
+View a workflow.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `name` (required): Name or ID of the workflow
+- `yaml` (optional): View the workflow YAML file
+
+### gh_workflow_run
+
+Run a workflow.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `name` (required): Name or ID of the workflow
+- `ref` (optional): Branch or tag name to run the workflow on
+
+### gh_workflow_disable
+
+Disable a workflow.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `name` (required): Name or ID of the workflow
+
+### gh_workflow_enable
+
+Enable a workflow.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `name` (required): Name or ID of the workflow
+
+## Release Tools
+
+### gh_release_list
+
+List releases in a repository.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `limit` (optional): Maximum number of releases to fetch
+
+### gh_release_view
+
+View a release.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `tag` (optional): Tag name of the release
+- `web` (optional): Open the release in the browser
+
+### gh_release_create
+
+Create a new release.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `tag` (required): Tag name for the release
+- `title` (optional): Title for the release
+- `notes` (optional): Release notes
+- `draft` (optional): Create as a draft release
+- `prerelease` (optional): Mark as a prerelease
+
+### gh_release_delete
+
+Delete a release.
+
+**Parameters:**
+- `repo` (optional): Repository name with owner (e.g., owner/repo)
+- `tag` (required): Tag name of the release to delete
+- `yes` (optional): Skip the confirmation prompt

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,106 @@
+# Configuration
+
+GitHub CLI MCP can be configured through a JSON configuration file or command-line arguments.
+
+## Configuration File
+
+Create a JSON configuration file (e.g., `gh-cli-mcp.config.json`) with the following structure:
+
+```json
+{
+  "sessionTimeout": 1800000,
+  "permissions": {
+    "allow": [
+      "mcp__github__gh_pr_list",
+      "mcp__github__gh_pr_view",
+      "mcp__github__gh_pr_create",
+      "mcp__github__gh_pr_close",
+      "mcp__github__gh_issue_list",
+      "mcp__github__gh_issue_view",
+      "mcp__github__gh_issue_create",
+      "mcp__github__gh_issue_close",
+      "mcp__github__gh_repo_view",
+      "mcp__github__gh_repo_list",
+      "mcp__github__gh_project_create",
+      "mcp__github__gh_project_list",
+      "mcp__github__gh_project_view"
+    ],
+    "deny": []
+  }
+}
+```
+
+### Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `sessionTimeout` | Timeout for inactive sessions (milliseconds) | 1800000 (30 minutes) |
+| `permissions.allow` | List of allowed tool names (empty array means all tools are allowed) | [] |
+| `permissions.deny` | List of denied tool names | [] |
+
+## Example Configuration Files
+
+### Default Configuration
+
+To use default settings, create a minimal configuration file:
+
+```json
+{
+  "sessionTimeout": 1800000
+}
+```
+
+### Restricted Access
+
+To restrict access to only specific tools:
+
+```json
+{
+  "sessionTimeout": 1800000,
+  "permissions": {
+    "allow": [
+      "mcp__github__gh_pr_list",
+      "mcp__github__gh_issue_list",
+      "mcp__github__gh_repo_view"
+    ],
+    "deny": []
+  }
+}
+```
+
+### Specific Denials
+
+To deny access to specific tools:
+
+```json
+{
+  "sessionTimeout": 1800000,
+  "permissions": {
+    "allow": [],
+    "deny": [
+      "mcp__github__gh_pr_create",
+      "mcp__github__gh_issue_create"
+    ]
+  }
+}
+```
+
+## Specifying the Configuration File
+
+You can specify the configuration file path using the `--config` command-line option:
+
+```bash
+gh-cli-mcp --config ./my-config.json
+```
+
+If no configuration file is specified, GitHub CLI MCP will look for a file named `gh-cli-mcp.config.json` in the current working directory.
+
+## Command-Line Overrides
+
+Command-line arguments take precedence over configuration file settings. For example:
+
+```bash
+gh-cli-mcp --session-timeout 3600000
+```
+
+This would set the session timeout to 3600000 milliseconds (1 hour), regardless of what is specified in the configuration file.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,118 @@
+# Frequently Asked Questions
+
+## General Questions
+
+### What is GitHub CLI MCP?
+
+GitHub CLI MCP is a server that wraps GitHub CLI commands, making them available to AI assistants through the Model Context Protocol (MCP). It allows AI assistants to interact with GitHub repositories programmatically.
+
+### What is the Model Context Protocol (MCP)?
+
+The Model Context Protocol (MCP) is a standardized interface for AI assistants to interact with external tools. It provides a way for AI assistants to call methods on external systems and receive structured responses.
+
+### What are the system requirements?
+
+- Node.js v18 or later
+- GitHub CLI (installed and authenticated)
+
+## Installation and Setup
+
+### How do I install GitHub CLI MCP?
+
+You can install GitHub CLI MCP via npm:
+
+```bash
+npm install -g gh-cli-mcp
+```
+
+See the [Installation Guide](Installation) for more details.
+
+### I'm getting an error about GitHub CLI not being installed or authenticated. How do I fix this?
+
+Make sure you have installed the GitHub CLI (`gh`) and that you've authenticated with GitHub:
+
+```bash
+# Install GitHub CLI (example for macOS with Homebrew)
+brew install gh
+
+# Authenticate with GitHub
+gh auth login
+```
+
+Follow the prompts to complete the authentication process.
+
+### How do I update GitHub CLI MCP to the latest version?
+
+To update to the latest version:
+
+```bash
+npm update -g gh-cli-mcp
+```
+
+## Configuration
+
+### Can I restrict which GitHub operations are allowed?
+
+Yes, you can use the permissions configuration to specify which tools are allowed or denied. See the [Configuration](Configuration) page for details.
+
+### How do I change the session timeout?
+
+You can change the session timeout either through the configuration file or via the command-line option:
+
+```bash
+gh-cli-mcp --session-timeout 3600000
+```
+
+This sets the timeout to 1 hour (3600000 milliseconds).
+
+## Usage
+
+### How do I start the server?
+
+```bash
+gh-cli-mcp
+```
+
+### How can I use GitHub CLI MCP with my AI assistant?
+
+GitHub CLI MCP can be used with any AI assistant that supports the Model Context Protocol. Configure your assistant to communicate with the GitHub CLI MCP server via stdio.
+
+### Does GitHub CLI MCP support multiple clients?
+
+No, GitHub CLI MCP only supports a single client using stdio transport.
+
+### Can I use GitHub CLI MCP with a private GitHub repository?
+
+Yes, as long as the GitHub CLI is authenticated with an account that has access to the private repository.
+
+## Troubleshooting
+
+### I'm getting "Command execution timed out" errors. How can I fix this?
+
+The default timeout for command execution is 30 seconds. If you're working with large repositories or slow network connections, you may need to handle timeouts gracefully in your client application.
+
+### How do I report bugs or request features?
+
+You can report bugs or request features by opening an issue on the [GitHub repository](https://github.com/CodingButterBot/gh_cli_mcp/issues).
+
+### I'm getting an error when trying to start the server. What should I check?
+
+1. Make sure Node.js v18 or later is installed
+2. Verify that GitHub CLI is installed and authenticated
+3. Check that there are no other instances of GitHub CLI MCP running
+4. Look for error messages in the console output
+
+## Development
+
+### How can I contribute to GitHub CLI MCP?
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Submit a pull request
+
+Please ensure your code follows the project's coding standards and includes appropriate tests.
+
+### Are there any plans to support additional GitHub features?
+
+GitHub CLI MCP aims to support all features available through the GitHub CLI. If there's a specific feature you'd like to see added, please open an issue on the GitHub repository.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,31 @@
+# GitHub CLI MCP
+
+Welcome to the GitHub CLI MCP wiki!
+
+GitHub CLI MCP is a server that wraps GitHub CLI commands, making them available to AI assistants through the Model Context Protocol (MCP). This allows AI assistants to interact with GitHub repositories programmatically.
+
+![GitHub CLI MCP](https://raw.githubusercontent.com/CodingButterBot/gh_cli_mcp/master/gh-cli-mcp.png)
+
+## Quick Links
+
+- [Installation Guide](Installation)
+- [Usage Guide](Usage)
+- [Configuration](Configuration)
+- [Available Tools](Available-Tools)
+- [FAQ](FAQ)
+
+## Key Features
+
+- Access GitHub functionality through standardized interfaces
+- Utilizes stdio for communication (simple integration)
+- Built with TypeScript for type safety
+- Built on top of the official GitHub CLI
+- Comprehensive set of tools for Pull Requests, Issues, Repositories, and more
+
+## Architecture
+
+GitHub CLI MCP wraps the official GitHub CLI (`gh`) executable, allowing for a standardized interface between AI assistants and GitHub. The server communicates with clients using the Model Context Protocol (MCP) via stdio.
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,68 @@
+# Installation Guide
+
+GitHub CLI MCP has a few prerequisites and can be installed via npm.
+
+## Prerequisites
+
+1. **Node.js** (v18 or later)
+2. **GitHub CLI** - Must be installed and authenticated
+
+## GitHub CLI Installation
+
+Before installing GitHub CLI MCP, you need to install and authenticate the GitHub CLI:
+
+### Installing GitHub CLI
+
+Follow the official instructions for your operating system:
+https://cli.github.com/manual/installation
+
+### Authenticating GitHub CLI
+
+Once installed, authenticate with your GitHub account:
+
+```bash
+gh auth login
+```
+
+Follow the prompts to authenticate with GitHub.
+
+## Installing GitHub CLI MCP
+
+### Via npm
+
+```bash
+npm install -g gh-cli-mcp
+```
+
+### From Source
+
+If you want to install from source:
+
+```bash
+# Clone the repository
+git clone https://github.com/CodingButterBot/gh_cli_mcp.git
+cd gh_cli_mcp
+
+# Install dependencies
+npm install
+
+# Build the project
+npm run build
+
+# Optional: Create a global symlink
+npm link
+```
+
+## Verifying Installation
+
+Verify that the installation was successful:
+
+```bash
+gh-cli-mcp --version
+```
+
+You should see output showing the version number of GitHub CLI MCP.
+
+## Next Steps
+
+Now that you have GitHub CLI MCP installed, check the [Usage Guide](Usage) to learn how to use it.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,0 +1,95 @@
+# Usage Guide
+
+This page explains how to use GitHub CLI MCP to enable AI assistants to interact with GitHub.
+
+## Starting the Server
+
+Start the GitHub CLI MCP server:
+
+```bash
+gh-cli-mcp
+```
+
+This starts the server using stdio transport.
+
+## Command Line Options
+
+GitHub CLI MCP supports the following command line options:
+
+```
+OPTIONS:
+  -h, --help                 Show this help message
+  -v, --version              Show version information
+  -c, --config <path>        Path to configuration file
+  --session-timeout <ms>     Session timeout in milliseconds
+```
+
+### Examples
+
+**Show help:**
+```bash
+gh-cli-mcp --help
+```
+
+**Start with a custom configuration file:**
+```bash
+gh-cli-mcp --config ./my-config.json
+```
+
+**Set a custom session timeout:**
+```bash
+gh-cli-mcp --session-timeout 3600000
+```
+
+## Integration with AI Assistants
+
+GitHub CLI MCP can be used with any AI assistant that supports the Model Context Protocol. Here's how to integrate it with your assistant:
+
+1. Start the GitHub CLI MCP server
+2. Configure your AI assistant to communicate with the server via stdio
+3. Use the Model Context Protocol to invoke GitHub CLI tools
+
+## Tool Invocation Examples
+
+Here are some examples of how to invoke GitHub CLI MCP tools:
+
+### Listing Pull Requests
+
+```json
+{
+  "name": "gh_pr_list",
+  "input": {
+    "state": "open"
+  }
+}
+```
+
+### Viewing a Pull Request
+
+```json
+{
+  "name": "gh_pr_view",
+  "input": {
+    "number": 123,
+    "repo": "owner/repo"
+  }
+}
+```
+
+### Creating an Issue
+
+```json
+{
+  "name": "gh_issue_create",
+  "input": {
+    "title": "Bug: Application crashes on startup",
+    "body": "When starting the application, it crashes with the following error...",
+    "repo": "owner/repo"
+  }
+}
+```
+
+## Next Steps
+
+- Check the [Configuration](Configuration) guide for advanced configuration options
+- See [Available Tools](Available-Tools) for a comprehensive list of available tools

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,0 +1,3 @@
+---
+
+*GitHub CLI MCP - Making GitHub CLI accessible to AI assistants via Model Context Protocol*

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,14 @@
+### GitHub CLI MCP
+
+* [Home](Home)
+* [Installation Guide](Installation)
+* [Usage Guide](Usage)
+* [Configuration](Configuration)
+* [Available Tools](Available-Tools)
+* [FAQ](FAQ)
+
+### Additional Resources
+
+* [GitHub Repository](https://github.com/CodingButterBot/gh_cli_mcp)
+* [Issue Tracker](https://github.com/CodingButterBot/gh_cli_mcp/issues)
+* [GitHub CLI Documentation](https://cli.github.com/manual/)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,18 @@
+title: GitHub CLI MCP
+description: GitHub CLI MCP server for AI assistants - Access GitHub via Model Context Protocol
+theme: jekyll-theme-cayman
+
+# Navigation
+navigation:
+  - title: Home
+    url: /
+  - title: Installation
+    url: /Installation
+  - title: Usage
+    url: /Usage
+  - title: Configuration
+    url: /Configuration
+  - title: Available Tools
+    url: /Available-Tools
+  - title: FAQ
+    url: /FAQ

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      <header>
+        <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
+        <nav>
+          <ul>
+            {% for item in site.navigation %}
+              <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </header>
+      <main>
+        {{ content }}
+      </main>
+      <footer>
+        <p>GitHub CLI MCP - Making GitHub CLI accessible to AI assistants via Model Context Protocol</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: GitHub CLI MCP
+---
+
+{% include_relative Home.md %}


### PR DESCRIPTION
This PR adds a documentation site using GitHub Pages that will serve as the project's wiki. After merging, please enable GitHub Pages in the repository settings pointing to the docs folder on the wiki branch.